### PR TITLE
Fixing bug with $ref type checking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - '5.10.1'
+services:

--- a/lib/json-schema.js
+++ b/lib/json-schema.js
@@ -50,7 +50,7 @@ var convert = function (refSchemas, jsonSchema) {
     if (!_.isPlainObject(jsonSchema)) {
         unsupportedJsonSchema(jsonSchema);
     }
-    var converted, result, format = jsonSchema.format, isRef = !_.isEmpty(jsonSchema.$ref), isTypeDate = jsonSchema.type === 'string' && (format === 'date' || format === 'date-time'), mongooseRef = typeRefToMongooseType[jsonSchema.$ref], isMongooseRef = !_.isEmpty(mongooseRef), subSchema = _.isEmpty(refSchemas) ? false : refSchemas[jsonSchema.$ref];
+    var converted, result, format = jsonSchema.format, isRef = !_.isEmpty(jsonSchema.$ref), isTypeDate = jsonSchema.type === 'string' && (format === 'date' || format === 'date-time'), mongooseRef = typeRefToMongooseType[jsonSchema.$ref], isMongooseRef = typeof(mongooseRef) != 'undefined' ? true : false, subSchema = _.isEmpty(refSchemas) ? false : refSchemas[jsonSchema.$ref];
     return (result =
         isRef
             ? isMongooseRef ? mongooseRef

--- a/lib/json-schema.js
+++ b/lib/json-schema.js
@@ -47,10 +47,38 @@ var toMongooseParams = function (acc, val, key) {
 var unsupportedRefValue = function (jsonSchema) { throw new Error("Unsupported $ref value: " + jsonSchema.$ref); };
 var unsupportedJsonSchema = function (jsonSchema) { throw new Error('Unsupported JSON schema type, `' + jsonSchema.type + '`'); };
 var convert = function (refSchemas, jsonSchema) {
+  
     if (!_.isPlainObject(jsonSchema)) {
         unsupportedJsonSchema(jsonSchema);
     }
-    var converted, result, format = jsonSchema.format, isRef = !_.isEmpty(jsonSchema.$ref), isTypeDate = jsonSchema.type === 'string' && (format === 'date' || format === 'date-time'), mongooseRef = typeRefToMongooseType[jsonSchema.$ref], isMongooseRef = typeof(mongooseRef) != 'undefined' ? true : false, subSchema = _.isEmpty(refSchemas) ? false : refSchemas[jsonSchema.$ref];
+    var converted,
+        result,
+        format = jsonSchema.format,
+        isRef = !_.isEmpty(jsonSchema.$ref),
+        isTypeDate = jsonSchema.type === 'string' && (format === 'date' || format === 'date-time'),
+        mongooseRef = typeRefToMongooseType[jsonSchema.$ref],
+        isMongooseRef = typeof(mongooseRef) != 'undefined' ? true : false,
+        subSchema = _.isEmpty(refSchemas) ? false : refSchemas[jsonSchema.$ref];
+
+    // @FIXME Hack for compliance with schemas which use arrays for type values
+    // and where one of the values is "null". e.g. Popolo schemas.
+    if (jsonSchema.type) {
+      // Look for types that are an array of two types
+      if (jsonSchema.type instanceof Array && jsonSchema.type.length == 2) {
+    
+        // If one of the times is null, remove it
+        jsonSchema.type.forEach(function(value, index) {
+          if (value == "null")
+            jsonSchema.type.splice(index, 1);
+        });
+    
+        // If the array now contains exactly one item, remove trailing comma
+        if (jsonSchema.type.length == 1) {
+          jsonSchema.type = jsonSchema.type[0].replace(/\,$/, '');
+        }
+      }
+    }
+        
     return (result =
         isRef
             ? isMongooseRef ? mongooseRef

--- a/lib/json-schema.ts
+++ b/lib/json-schema.ts
@@ -72,7 +72,7 @@ var convert = (refSchemas: any, jsonSchema: any): any => {
         isRef = !_.isEmpty(jsonSchema.$ref),
         isTypeDate = jsonSchema.type === 'string' && (format === 'date' || format === 'date-time'),
         mongooseRef = typeRefToMongooseType[jsonSchema.$ref],
-        isMongooseRef = !_.isEmpty(mongooseRef),
+        isMongooseRef = typeof(mongooseRef) != 'undefined' ? true : false,
         subSchema = _.isEmpty(refSchemas)? false: refSchemas[jsonSchema.$ref]
 
     return (result =

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-schema-to-mongoose",
-    "version": "0.2.3",
+    "version": "0.2.4",
   "description": "A library for converting json-schema to mongoose schema",
   "keywords": [
     "json_schema",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-schema-to-mongoose",
-    "version": "0.2.2",
+    "version": "0.2.3",
   "description": "A library for converting json-schema to mongoose schema",
   "keywords": [
     "json_schema",


### PR DESCRIPTION
JSON-schema objects defined as { $ref: "#/definitions/objectid" } were not being turned into mongoose properties with a type mongoose.Schema.Types.ObjectId due to a conditional bug.

This has been fixed, although I have not provided an additional test for the issue.