### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "lodash": "^3.6.0",
-    "mongoose": "~3.6.18"
+    "mongoose": "~4.7.1"
   },
   "devDependencies": {
     "jasmine-node": "^2.0.0"


### PR DESCRIPTION
updating the mongoose version to work with other modules (error with how npm3 installs at a top level)
```
app/node_modules/json-schema-to-mongoose/node_modules/mongoose/lib/drivers/node-mongodb-native/objectid.js:8
var ObjectId = require('mongodb').BSONPure.ObjectID;
                                          ^
TypeError: Cannot read property 'ObjectID' of undefined
```

```
> json-schema-to-mongoose@0.2.2 test /Users/apratt/dev/PWS/vendor-api/node_modules/json-schema-to-mongoose
> jasmine-node ./test

.....

Finished in 0.01 seconds
5 Tests, 0 Failures, 0 Skipped
```