### PR TITLE
Adding support for JsonSchema Draft4

### DIFF
--- a/lib/json-schema.js
+++ b/lib/json-schema.js
@@ -11,9 +11,16 @@ var typeRefToMongooseType = {
     '#/definitions/objectid': mongoose.Schema.Types.ObjectId,
     '#/definitions/dateOrDatetime': Date
 };
-var subSchemaType = function (parentSchema, subschema, key) {
+var subSchemaTypeV3 = function (parentSchema, subschema, key) {
     return (parentSchema.required.indexOf(key) >= 0 && !_.isPlainObject(subschema)) ?
         { type: subschema, required: true }
+        : subschema;
+};
+var subSchemaTypeV4 = function (parentSchema, subschema, key) {
+    return (parentSchema.required.indexOf(key) >= 0 ) 
+    	? !_.isPlainObject(subschema) 
+    		? { type: subschema, required: true }
+    		: _.assign(subschema, {required: true})
         : subschema;
 };
 var schemaParamsToMongoose = {
@@ -47,10 +54,24 @@ var toMongooseParams = function (acc, val, key) {
 var unsupportedRefValue = function (jsonSchema) { throw new Error("Unsupported $ref value: " + jsonSchema.$ref); };
 var unsupportedJsonSchema = function (jsonSchema) { throw new Error('Unsupported JSON schema type, `' + jsonSchema.type + '`'); };
 var convert = function (refSchemas, jsonSchema) {
-  
-    if (!_.isPlainObject(jsonSchema)) {
-        unsupportedJsonSchema(jsonSchema);
-    }
+	if (!_.isPlainObject(jsonSchema)) {
+		unsupportedJsonSchema(jsonSchema);
+	}
+	
+	if (jsonSchema.$schema === 'http://json-schema.org/draft-03/schema#') {
+		return convertV(3, refSchemas, jsonSchema);
+	}
+	else if (jsonSchema.$schema === 'http://json-schema.org/draft-04/schema#') {
+		return convertV(4, refSchemas, jsonSchema);
+	}
+	// backwards compatibility
+	else {
+		return convertV(3, refSchemas, jsonSchema);
+	}
+}
+
+var convertV = function (version, refSchemas, jsonSchema) {
+    
     var converted,
         result,
         format = jsonSchema.format,
@@ -58,7 +79,8 @@ var convert = function (refSchemas, jsonSchema) {
         isTypeDate = jsonSchema.type === 'string' && (format === 'date' || format === 'date-time'),
         mongooseRef = typeRefToMongooseType[jsonSchema.$ref],
         isMongooseRef = typeof(mongooseRef) != 'undefined' ? true : false,
-        subSchema = _.isEmpty(refSchemas) ? false : refSchemas[jsonSchema.$ref];
+        subSchema = _.isEmpty(refSchemas) ? false : refSchemas[jsonSchema.$ref]
+    	subSchemaType = (version == 4) ? subSchemaTypeV4 : subSchemaTypeV3;
 
     // @FIXME Hack for compliance with schemas which use arrays for type values
     // and where one of the values is "null". e.g. Popolo schemas.
@@ -81,8 +103,10 @@ var convert = function (refSchemas, jsonSchema) {
         
     return (result =
         isRef
-            ? isMongooseRef ? mongooseRef
-                : subSchema ? convert(refSchemas, subSchema)
+            ? isMongooseRef 
+            	? mongooseRef
+                : subSchema 
+                	? convertV(version, refSchemas, subSchema)
                     : unsupportedRefValue(jsonSchema)
             : isTypeDate
                 ? _.reduce(_.omit(jsonSchema, 'type', 'format'), toMongooseParams, { type: typeRefToMongooseType['#/definitions/dateOrDatetime'] })
@@ -91,16 +115,19 @@ var convert = function (refSchemas, jsonSchema) {
                     : (jsonSchema.type === 'object')
                         ? _.isEmpty(jsonSchema.properties)
                             ? mongoose.Schema.Types.Mixed
-                            : (converted = _.mapValues(jsonSchema.properties, convert.bind(null, refSchemas)),
-                                jsonSchema.required ? (_.mapValues(converted, subSchemaType.bind(null, jsonSchema))) : converted)
+                            : (converted = _.mapValues(jsonSchema.properties, convertV.bind(null, version, refSchemas)),
+                                jsonSchema.required 
+                                	? (_.mapValues(converted, subSchemaType.bind(null, jsonSchema))) 
+                                	: converted)
                         : (jsonSchema.type === 'array')
                             ? !_.isEmpty(jsonSchema.items)
-                                ? [convert(refSchemas, jsonSchema.items)]
+                                ? [convertV(version, refSchemas, jsonSchema.items)]
                                 : []
                             : !_.has(jsonSchema, 'type')
                                 ? mongoose.Schema.Types.Mixed
                                 : unsupportedJsonSchema(jsonSchema));
 };
+
 var createMongooseSchema = _.curry(convert);
 module.exports = createMongooseSchema;
 //# sourceMappingURL=json-schema.js.map

--- a/lib/json-schema.js
+++ b/lib/json-schema.js
@@ -54,9 +54,6 @@ var toMongooseParams = function (acc, val, key) {
 var unsupportedRefValue = function (jsonSchema) { throw new Error("Unsupported $ref value: " + jsonSchema.$ref); };
 var unsupportedJsonSchema = function (jsonSchema) { throw new Error('Unsupported JSON schema type, `' + jsonSchema.type + '`'); };
 var convert = function (refSchemas, jsonSchema) {
-	if (!_.isPlainObject(jsonSchema)) {
-		unsupportedJsonSchema(jsonSchema);
-	}
 	
 	if (jsonSchema.$schema === 'http://json-schema.org/draft-03/schema#') {
 		return convertV(3, refSchemas, jsonSchema);
@@ -71,7 +68,10 @@ var convert = function (refSchemas, jsonSchema) {
 }
 
 var convertV = function (version, refSchemas, jsonSchema) {
-    
+	if (!_.isPlainObject(jsonSchema)) {
+		unsupportedJsonSchema(jsonSchema);
+	}
+	
     var converted,
         result,
         format = jsonSchema.format,

--- a/lib/json-schema.ts
+++ b/lib/json-schema.ts
@@ -70,9 +70,6 @@ var toMongooseParams = (acc, val, key) => {
 var unsupportedRefValue = (jsonSchema) => { throw new Error("Unsupported $ref value: " + jsonSchema.$ref) }
 var unsupportedJsonSchema = (jsonSchema) => { throw new Error('Unsupported JSON schema type, `' + jsonSchema.type + '`') }
 var convert = (refSchemas: any, jsonSchema: any): any => {
-    if (!_.isPlainObject(jsonSchema)) {
-        unsupportedJsonSchema(jsonSchema);
-    }
     
     if (jsonSchema.$schema === 'http://json-schema.org/draft-03/schema#') {
         return convertV(3, refSchemas, jsonSchema);

--- a/lib/json-schema.ts
+++ b/lib/json-schema.ts
@@ -16,11 +16,20 @@ var typeRefToMongooseType = {
     
 }
 
-var subSchemaType = (parentSchema, subschema, key) =>
+var subSchemaTypeV3 = (parentSchema, subschema, key) =>
 {
     return (parentSchema.required.indexOf(key) >= 0 && !_.isPlainObject(subschema))?
            { type: subschema, required: true }
            : subschema
+}
+
+var subSchemaTypeV4 = (parentSchema, subschema, key) =>
+{
+    return (parentSchema.required.indexOf(key) >= 0 )
+            ? !_.isPlainObject(subschema) 
+                ? { type: subschema, required: true }
+                : _.assign(subschema, {required: true})
+            : subschema
 }
 
 var schemaParamsToMongoose =
@@ -61,6 +70,23 @@ var toMongooseParams = (acc, val, key) => {
 var unsupportedRefValue = (jsonSchema) => { throw new Error("Unsupported $ref value: " + jsonSchema.$ref) }
 var unsupportedJsonSchema = (jsonSchema) => { throw new Error('Unsupported JSON schema type, `' + jsonSchema.type + '`') }
 var convert = (refSchemas: any, jsonSchema: any): any => {
+    if (!_.isPlainObject(jsonSchema)) {
+        unsupportedJsonSchema(jsonSchema);
+    }
+    
+    if (jsonSchema.$schema === 'http://json-schema.org/draft-03/schema#') {
+        return convertV(3, refSchemas, jsonSchema);
+    }
+    else if (jsonSchema.$schema === 'http://json-schema.org/draft-04/schema#') {
+        return convertV(4, refSchemas, jsonSchema);
+    }
+    // backwards compatibility
+    else {
+        return convertV(3, refSchemas, jsonSchema);
+    }
+}
+
+var convertV = (version: any, refSchemas: any, jsonSchema: any): any => {
 
     if (!_.isPlainObject(jsonSchema)) {
         unsupportedJsonSchema(jsonSchema)
@@ -74,11 +100,12 @@ var convert = (refSchemas: any, jsonSchema: any): any => {
         mongooseRef = typeRefToMongooseType[jsonSchema.$ref],
         isMongooseRef = typeof(mongooseRef) != 'undefined' ? true : false,
         subSchema = _.isEmpty(refSchemas)? false: refSchemas[jsonSchema.$ref]
-
+        subSchemaType = (version == 4) ? subSchemaTypeV4 : subSchemaTypeV3
+    
     return (result =
         isRef
             ? isMongooseRef? mongooseRef
-            : subSchema? convert(refSchemas, subSchema)
+            : subSchema? convertV(version, refSchemas, subSchema)
             : unsupportedRefValue(jsonSchema)
 
         : isTypeDate
@@ -93,12 +120,12 @@ var convert = (refSchemas: any, jsonSchema: any): any => {
         : (jsonSchema.type === 'object')
             ? _.isEmpty(jsonSchema.properties)
                 ? mongoose.Schema.Types.Mixed
-            : ( converted = _.mapValues(jsonSchema.properties, convert.bind(null, refSchemas)),
+            : ( converted = _.mapValues(jsonSchema.properties, convertV.bind(null, version, refSchemas)),
                 jsonSchema.required? (_.mapValues(converted, subSchemaType.bind(null, jsonSchema))): converted )
 
         : (jsonSchema.type === 'array')
             ? !_.isEmpty(jsonSchema.items)
-                ? [convert(refSchemas, jsonSchema.items)]
+                ? [convertV(version, refSchemas, jsonSchema.items)]
             : []
 
         : !_.has(jsonSchema, 'type')


### PR DESCRIPTION
Previously only Draft 3 was supported.
This handles Draft 4's handling of the required keyword.

By default the old method is used, draft 4 will only be used if $schema='http://json-schema.org/draft-04/schema#'