### PR TITLE
Fix issue #11

### DIFF
--- a/lib/json-schema.js
+++ b/lib/json-schema.js
@@ -20,7 +20,9 @@ var subSchemaTypeV4 = function (parentSchema, subschema, key) {
     return (parentSchema.required.indexOf(key) >= 0 ) 
     	? !_.isPlainObject(subschema) 
     		? { type: subschema, required: true }
-    		: _.assign(subschema, {required: true})
+    		: subschema.hasOwnProperty('type')
+				? _.assign(subschema, {required: true})
+				: subschema
         : subschema;
 };
 var schemaParamsToMongoose = {

--- a/lib/json-schema.ts
+++ b/lib/json-schema.ts
@@ -28,7 +28,9 @@ var subSchemaTypeV4 = (parentSchema, subschema, key) =>
     return (parentSchema.required.indexOf(key) >= 0 )
             ? !_.isPlainObject(subschema) 
                 ? { type: subschema, required: true }
-                : _.assign(subschema, {required: true})
+				: subschema.hasOwnProperty('type')
+					?_.assign(subschema, {required: true})
+					: subschema
             : subschema
 }
 


### PR DESCRIPTION
Fixing Issue #11
If the schema has type='object' then the subschema will have been rendered without a 'type' key, so we can simply check for the existence of the 'type' key on the subschema.